### PR TITLE
Update HttpUtility.cs

### DIFF
--- a/PortableRazor.Web/HttpUtility.cs
+++ b/PortableRazor.Web/HttpUtility.cs
@@ -129,8 +129,9 @@ namespace PortableRazor.Web
 					namePos = valueEnd + 1;
 				}
 				value = System.Net.WebUtility.UrlDecode (decoded.Substring (valuePos, valueEnd - valuePos));
-
-				result.Add (name, value);
+				
+				if (name != null)
+					result.Add (name, value);
 				if (namePos == -1)
 					break;
 			}


### PR DESCRIPTION
Fixed exception being thrown when a URL is provided ParseQueryString() without any query parameters